### PR TITLE
Add analysis layer unit tests (Issue #53)

### DIFF
--- a/backend/tests/test_analysis_api.py
+++ b/backend/tests/test_analysis_api.py
@@ -1,0 +1,41 @@
+import unittest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+class TestAnalysisAPI(unittest.TestCase):
+
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_summarize_endpoint(self):
+        response = self.client.post("/api/analysis/summarize", json=[1, 2, 3])
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["message"], "Summarization endpoint ready")
+        self.assertEqual(data["text_ids"], [1, 2, 3])
+
+    def test_sentiment_endpoint(self):
+        response = self.client.post("/api/analysis/sentiment", json=[42])
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["message"], "Sentiment endpoint ready")
+
+    def test_trends_endpoint(self):
+        response = self.client.post("/api/analysis/trends?timeframe=30d")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["message"], "Trend detection endpoint ready")
+        self.assertEqual(data["timeframe"], "30d")
+
+    def test_insights_endpoint(self):
+        response = self.client.post("/api/analysis/insights?topic=semiconductors")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["message"], "Insights endpoint ready")
+        self.assertEqual(data["topic"], "semiconductors")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_analysis_service.py
+++ b/backend/tests/test_analysis_service.py
@@ -1,0 +1,125 @@
+import json
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from app.services.analysis_service import AnalysisService
+
+
+class TestAnalysisService:
+
+    @pytest.fixture
+    def service(self):
+        return AnalysisService(api_key="sk-test", model="test-model")
+
+    @pytest.mark.asyncio
+    async def test_summarize_short_text(self, service):
+        result = await service.summarize("Short")
+        assert result == "Text too short to summarize."
+
+    @pytest.mark.asyncio
+    async def test_summarize_normal_text(self, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Mocked summary result"}}]
+        }
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.summarize("This is a long enough text to trigger the LLM summarization call successfully.")
+        assert result == "Mocked summary result"
+
+    @pytest.mark.asyncio
+    async def test_analyze_sentiment_valid_json(self, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": json.dumps({"sentiment": "positive", "score": 0.85})}}]
+        }
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.analyze_sentiment("Great results this quarter!")
+        assert result == {"sentiment": "positive", "score": 0.85}
+
+    @pytest.mark.asyncio
+    async def test_analyze_sentiment_invalid_json(self, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "This is not valid JSON"}}]
+        }
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.analyze_sentiment("Some text")
+        assert result == {"sentiment": "neutral", "score": 0.5}
+
+    @pytest.mark.asyncio
+    async def test_detect_trends_valid_json(self, service):
+        expected_trends = [
+            {"trend": "AI chips", "count": 5, "keywords": ["AI", "chips"]},
+            {"trend": "Biotech", "count": 3, "keywords": ["biotech", "FDA"]}
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": json.dumps(expected_trends)}}]
+        }
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.detect_trends(["AI chip demand surges", "Biotech breakthrough"])
+        assert result == expected_trends
+
+    @pytest.mark.asyncio
+    async def test_detect_trends_invalid_json(self, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Not JSON"}}]
+        }
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.detect_trends(["Some title"])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_extract_insights_valid_json(self, service):
+        expected_insights = [
+            {"insight": "Market growth", "importance": 4, "related_companies": ["AAPL"]}
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": json.dumps(expected_insights)}}]
+        }
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.extract_insights(["Long article text about market growth"])
+        assert result == expected_insights
+
+    @pytest.mark.asyncio
+    async def test_extract_insights_invalid_json(self, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Not valid JSON at all"}}]
+        }
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.extract_insights(["Some article"])
+        assert result == [{"insight": "Analysis unavailable", "importance": 1, "related_companies": []}]
+
+    @pytest.mark.asyncio
+    async def test_generate_report_valid_json(self, service):
+        expected_report = {
+            "executive_summary": "Key findings on semiconductors.",
+            "key_findings": ["Finding 1", "Finding 2"],
+            "recommendations": ["Invest in AI chips"],
+            "confidence": 0.9
+        }
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": json.dumps(expected_report)}}]
+        }
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.generate_report("semiconductors", ["Article about semiconductor market"])
+        assert result == expected_report
+
+    @pytest.mark.asyncio
+    async def test_generate_report_invalid_json(self, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Broken response"}}]
+        }
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.generate_report("topic", ["Some text"])
+        assert result == {
+            "executive_summary": "Report generation pending.",
+            "key_findings": [],
+            "recommendations": [],
+            "confidence": 0.0
+        }


### PR DESCRIPTION
## Summary

Adds missing backend unit tests for the current analysis layer. No production code was modified — only new test coverage.

## Changes

- **`backend/tests/test_analysis_service.py`** — 10 async unit tests for `AnalysisService` (short-text guard, valid/invalid JSON fallback for sentiment, trends, insights, report generation)
- **`backend/tests/test_analysis_api.py`** — 4 API endpoint tests locking the current stub contracts for `/api/analysis/summarize`, `/api/analysis/sentiment`, `/api/analysis/trends`, `/api/analysis/insights`

## Verification

- All 14 new tests pass
- No production code changed
- Reviewed and approved by hyx2012ll

Closes #53