### PR TITLE
Add GET /api/reports/status endpoint (Issue #57)

### DIFF
--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from app.database import SessionLocal
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timezone
 from pydantic import BaseModel
 
 router = APIRouter(prefix="/api/reports", tags=["reports"])
@@ -67,6 +67,21 @@ def generate_report(payload: ReportGenerateRequest):
     }
     reports_db.append(report)
     return {"report": report}
+
+
+@router.get("/status")
+def get_reports_status():
+    """Get report status summary."""
+    total = len(reports_db)
+    completed = sum(1 for r in reports_db if r.get("status") == "completed")
+    pending = sum(1 for r in reports_db if r.get("status") == "pending")
+    return {
+        "total_reports": total,
+        "completed_reports": completed,
+        "pending_reports": pending,
+        "status": "ok",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
 
 
 @router.get("/{report_id}")

--- a/backend/tests/test_reports_status.py
+++ b/backend/tests/test_reports_status.py
@@ -1,0 +1,60 @@
+from fastapi.testclient import TestClient
+from app.main import app
+from app.routers.reports import reports_db
+
+client = TestClient(app)
+
+
+def setup_function():
+    reports_db.clear()
+
+
+def test_status_empty():
+    resp = client.get("/api/reports/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_reports"] == 0
+    assert data["completed_reports"] == 0
+    assert data["pending_reports"] == 0
+    assert data["status"] == "ok"
+    assert "generated_at" in data
+
+
+def test_status_some_completed():
+    reports_db.extend([
+        {"id": 1, "status": "completed"},
+        {"id": 2, "status": "completed"},
+    ])
+    resp = client.get("/api/reports/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_reports"] == 2
+    assert data["completed_reports"] == 2
+    assert data["pending_reports"] == 0
+
+
+def test_status_some_pending():
+    reports_db.extend([
+        {"id": 1, "status": "pending"},
+        {"id": 2, "status": "completed"},
+        {"id": 3, "status": "pending"},
+    ])
+    resp = client.get("/api/reports/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_reports"] == 3
+    assert data["completed_reports"] == 1
+    assert data["pending_reports"] == 2
+
+
+def test_generated_at_iso8601():
+    resp = client.get("/api/reports/status")
+    data = resp.json()
+    assert "T" in data["generated_at"]
+    assert data["generated_at"].endswith("+00:00") or "Z" in data["generated_at"]
+
+
+def test_status_field_ok():
+    resp = client.get("/api/reports/status")
+    data = resp.json()
+    assert data["status"] == "ok"


### PR DESCRIPTION
Implements GET /api/reports/status endpoint.

- Route declared before dynamic /{report_id}
- Counts derived from in-memory reports_db
- Tests via FastAPI TestClient (5 tests, all passing)

Closes #57