### PR TITLE
Fix local backend/frontend startup flow (Issue #60)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
 __pycache__/
 *.pyc
+node_modules/
+.env
+.venv/
+venv/
+.DS_Store
+build/
+dist/
+*.log
+.vscode/
+.idea/
+.pytest_cache/

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,3 +11,8 @@ app.include_router(sources_router)
 @app.get("/health")
 def health_check():
     return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,10 +9,12 @@
     "axios": "^1.6.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",
+    "dev": "react-scripts start",
     "build": "react-scripts build"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Fixes pull-and-run local development for both backend and frontend.

## Changes

1. **backend/main.py** — Added `if __name__ == "__main__"` block with `uvicorn.run()` so `python3 main.py` from `backend/` starts the FastAPI server on `0.0.0.0:8000`.
2. **frontend/package.json** — Added `react-scripts` to dependencies and `"dev": "react-scripts start"` script so `npm install && npm run dev` works.
3. **.gitignore** — Expanded with entries for `node_modules/`, `.env`, `.venv/`, `venv/`, `.DS_Store`, `build/`, `dist/`, `*.log`, `.vscode/`, `.idea/`, `.pytest_cache/`.

## Testing

- 28 backend tests passed (excluding 5 pre-existing broken tests).
- Branch hygiene: clean (no generated/artifact files committed).

## Review

Reviewed by hyx2012ll — APPROVED.