### PR TITLE
Fix: correct backend entrypoint and frontend dependency tree (Issue #63)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,18 +1,14 @@
-from fastapi import FastAPI
-from app.routers.search import router as search_router
-from app.routers.sources import router as sources_router
-
-app = FastAPI(title="LifeScience API")
-
-app.include_router(search_router)
-app.include_router(sources_router)
-
-
-@app.get("/health")
-def health_check():
-    return {"status": "ok"}
-
+"""
+Startup entry point for the FastAPI backend.
+Usage: python3 main.py
+"""
+import uvicorn
 
 if __name__ == "__main__":
-    import uvicorn
-    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run(
+        "app.main:app",
+        host="0.0.0.0",
+        port=8000,
+        reload=True,
+        log_level="info"
+    )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "axios": "^1.6.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "typescript": "^5.3.0",
+    "typescript": "^4.9.5",
     "react-scripts": "^5.0.1"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Follow-up bug fix for Issue #60 / PR #62. The initial merge had two defects that prevented actual pull-and-run development.

## Changes

1. **backend/main.py** — Replaced old wrapper (serving search/sources-only app) with a thin entrypoint that delegates to `app.main:app` (the full product app with alerts, reports, dashboard, analysis routers).
2. **frontend/package.json** — Downgraded `typescript` from `^5.3.0` to `^4.9.5` to match `react-scripts@5.0.1` peer dependency requirement.

## Verification

- Backend import verified: routes include `/`, `/api/alerts`, `/api/reports`, `/api/dashboard`, `/api/analysis`
- 28 backend tests passed
- Branch hygiene: clean

## Review

Reviewed by hyx2012ll — APPROVED.