### PR TITLE
Fix CORS and Docker frontend request (Issue #73)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,17 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.routers import alerts, reports, dashboard, analysis, auth, sources
 
 app = FastAPI(title="Life Science Data Platform", version="1")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000", "http://localhost"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(alerts.router)
 app.include_router(reports.router)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,10 @@ services:
         condition: service_healthy
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        REACT_APP_API_URL: ""
     ports:
       - "3000:80"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,7 @@
 # Stage 1: Build
 FROM node:18-alpine AS build
+ARG REACT_APP_API_URL
+ENV REACT_APP_API_URL=$REACT_APP_API_URL
 WORKDIR /app
 COPY package.json .
 RUN npm install


### PR DESCRIPTION
Fixes:#73

Changes:
- Add CORS middleware in backend (allow localhost:3000 and localhost)
- Add REACT_APP_API_URL build arg in frontend Dockerfile (Docker build can pass empty string so frontend uses relative paths)
- Update docker-compose.yml frontend service to pass the build arg